### PR TITLE
Bump pillow from 5.2.0 to 6.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib==2.2.2
 networkx==2.1
 numpy==1.15.0
 pandas==0.23.4
-Pillow==5.2.0
+Pillow==6.2.0
 pycparser==2.18
 pygit==0.1
 pyparsing==2.2.0


### PR DESCRIPTION
   ###@Bumps [pillow](https://github.com/python-pillow/Pillow) from 5.2.0 to 6.2.0.
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/5.2.0...6.2.0)